### PR TITLE
fix unclosed polling connections to mpd

### DIFF
--- a/lyvi/players/mpd.py
+++ b/lyvi/players/mpd.py
@@ -18,7 +18,7 @@ class Player(Player):
     @classmethod
     def running(self):
         try:
-            Telnet(lyvi.config['mpd_host'], lyvi.config['mpd_port'])
+            Telnet(lyvi.config['mpd_host'], lyvi.config['mpd_port']).close()
             return True
         except OSError:
             return False


### PR DESCRIPTION
Every second the main loop checks if the player(s) is still running.
With mpd this means trying to open a connection. The Telnet() call was
only checked for errors and if it succeeded never closed.
