### PR TITLE
Use cmus-remote to figure out if cmus is running

### DIFF
--- a/lyvi/players/cmus.py
+++ b/lyvi/players/cmus.py
@@ -15,7 +15,7 @@ from lyvi.utils import check_output
 class Player(Player):
     @classmethod
     def running(self):
-        return os.path.exists(os.environ['HOME'] + '/.cmus/socket')
+        return os.system('cmus-remote -C') == 0
 
     def get_status(self):
         data = {'artist': None, 'album': None, 'title': None, 'file': None, 'length': None}


### PR DESCRIPTION
Old version checked the existence of unix socket instead. This caused a problem because the socket location is different in case XDG_RUNTIME_DIR environment variable is set (see https://github.com/cmus/cmus/blob/master/misc.c#L221) - the code could check this additional location too, but this solution felt better since the code is using cmus-remote already anyway.

Blame told me that XDG_RUNTIME_DIR change is new - might not be an issue with ArchLinux cmus package, but I ran into problems when using cmus-git. 'cmus-remote -C' has apparently been there forever, though - see https://github.com/cmus/cmus/blame/master/main.c#L146.
