### PR TITLE
fix difference on save_lyrics option naming

### DIFF
--- a/lyvi/metadata.py
+++ b/lyvi/metadata.py
@@ -140,7 +140,7 @@ class Metadata:
                 '<artist>': self.artist,
                 '<title>': self.title,
                 '<album>': self.album
-            }:
+            }.items():
                 file = file.replace(k, v)
             if not os.path.exists(os.path.dirname(file)):
                 os.makedirs(os.path.dirname(file))


### PR DESCRIPTION
fix error on looking for the wrong option name on lyvi.config, not even documented ( https://github.com/ok100/lyvi/blob/master/doc/lyvi.1.rst#metadata-saving )
